### PR TITLE
Custom Log Message display for unsupported languages + Adding Example and Docs

### DIFF
--- a/examples/MetaCall_Kernel_Unsupported_Language_Notebook.ipynb
+++ b/examples/MetaCall_Kernel_Unsupported_Language_Notebook.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ea536a8d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "We don't suppport Rust language, yet.\n",
+      "Please try with another language or add support for Rust language.\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Rust: Print the values passed to a function\n",
+    "\n",
+    "fn main() {\n",
+    "    another_function(5, 6);\n",
+    "}\n",
+    "\n",
+    "fn another_function(x: i32, y: i32) {\n",
+    "    println!(\"The value of x is: {}\", x);\n",
+    "    println!(\"The value of y is: {}\", y);\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e0b521e1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "We don't suppport Go language, yet.\n",
+      "Please try with another language or add support for Go language.\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Golang: Calculate the area of the rectangle using a function\n",
+    "\n",
+    "package main\n",
+    "import \"fmt\"\n",
+    "\n",
+    "func area(length, width int)int{\n",
+    "     \n",
+    "    Ar := length* width\n",
+    "    return Ar\n",
+    "}\n",
+    " \n",
+    "\n",
+    "func main() {\n",
+    "   fmt.Printf(\"Area of rectangle is : %d\", area(12, 10))\n",
+    "}"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "metacall_jupyter",
+   "language": "text",
+   "name": "metacall_jupyter"
+  },
+  "language_info": {
+   "file_extension": ".txt",
+   "mimetype": "text/plain",
+   "name": "MetaCall Core"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,9 @@
+# Example Notebooks
+
+The following example notebooks display the use-case of MetaCall Core in an IPython environment through Jupyter Notebooks. Jupyter notebooks provide a feature-rich interface where they can capitalize on visualizations, figures, plots and user-interface elements to prototype the code they are writing and working on.
+
+## Examples
+
+- [JavaScript Notebook](JavaScript_Example_Notebook.ipynb): Displays the execution of Node Scripts on an IPython environment.
+- [MetaCall Kernel Example Notebook](MetaCall_Kernel_Example_Notebook.ipynb): Displays the execution of Python and Node Scripts on an IPython environment.
+- [MetaCall Kernel Unsupported Language Notebook](MetaCall_Kernel_Unsupported_Language_Notebook.ipynb): Displays the custom log messags displayed due to unsupported languages by the MetaCall Kernel, on an IPython environment.


### PR DESCRIPTION
# Description

This PR adds a Custom Log Message display for unsupported languages on the MetaCall Jupyter Kernel. It also adds more examples and corresponding Docs for the same.

Fixes #15 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [X] Documentation update
