### PR TITLE
Embed the MetaCall Polyglot REPL in the Kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,7 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# JavaScript
+
+node_modules/

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ python3 -m pip install --upgrade pip
 pip3 install -r requirements.txt
 python3 setup.py install
 python3 -m metacall_jupyter.install
+npm install
 ```
 
 Start your Jupyter Notebook by pushing the following command:
@@ -37,7 +38,7 @@ Start your Jupyter Notebook by pushing the following command:
 python3 -m metacall_jupyter.launcher
 ```
 
-You can pick `metacall_jupyter` from the drop-down options and start working with the Jupyter Notebook interface. An example notebook showing the execution of Node Scripts can be found [here](examples).
+You can pick `metacall_jupyter` from the drop-down options and start working with the Jupyter Notebook interface. Example Notebook are found [here](examples).
 
 ## Docker
 

--- a/examples/MetaCall_Kernel_REPL_Example.ipynb
+++ b/examples/MetaCall_Kernel_REPL_Example.ipynb
@@ -1,0 +1,213 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "de8a2f84",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Node REPL has been selected"
+     ]
+    }
+   ],
+   "source": [
+    "%repl node"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "915fb520",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "undefined"
+     ]
+    }
+   ],
+   "source": [
+    "let a = 2;\n",
+    "let b = 3;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4ec4070d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5"
+     ]
+    }
+   ],
+   "source": [
+    "a + b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "52553b19",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-1"
+     ]
+    }
+   ],
+   "source": [
+    "a - b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "22f9f115",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Python REPL has been selected"
+     ]
+    }
+   ],
+   "source": [
+    "%repl py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "00bb3b8f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    }
+   ],
+   "source": [
+    "def sum(a,b):\n",
+    "    return a + b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "556e3779",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5"
+     ]
+    }
+   ],
+   "source": [
+    "print(sum(2,3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "81059dca",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    }
+   ],
+   "source": [
+    "def sub(a,b):\n",
+    "    return a - b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "f8f08128",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2"
+     ]
+    }
+   ],
+   "source": [
+    "print(sub(7,5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "1b280bdb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    }
+   ],
+   "source": [
+    "from metacall import metacall_load_from_memory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "ec39e684",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5"
+     ]
+    }
+   ],
+   "source": [
+    "metacall_load_from_memory(\"node\", \"console.log(2+3)\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "metacall_jupyter",
+   "language": "text",
+   "name": "metacall_jupyter"
+  },
+  "language_info": {
+   "file_extension": ".txt",
+   "mimetype": "text/plain",
+   "name": "MetaCall Core"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,3 +9,4 @@ The following example notebooks display the use-case of MetaCall Core in an IPyt
 - [MetaCall Kernel Unsupported Language Notebook](MetaCall_Kernel_Unsupported_Language_Notebook.ipynb): Displays the custom log messags displayed due to unsupported languages by the MetaCall Kernel, on an IPython environment.
 - [MetaCall Kernel Magics Notebook](MetaCall_Kernel_Magics_Notebook.ipynb): Displays the use-case of `magics` like `%Python` and `%JavaScript` by the MetaCall Kernel, to execute code without `guesslang` inference, on an IPython environment.
 - [MetaCall Kernel Shell Commands](MetaCall_Kernel_Shell_Commands.ipynb): Displays the use-case of shell commands to install packages and run them through the Jupyter Notebook.
+- [MetaCall Kernel REPL Demonstration](MetaCall_Kernel_REPL_Example.ipynb): Displays the use-case of Polyglot REPL on the MetaCall Kernel and run them through the Jupyter Notebook.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "jupyter-kernel-repl",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "jupyter-kernel-repl",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "metacall-polyglot-repl": "github:metacall/polyglot-repl"
+      }
+    },
+    "node_modules/metacall-polyglot-repl": {
+      "version": "0.1.1",
+      "resolved": "git+ssh://git@github.com/metacall/polyglot-repl.git#d11d4bcf8ae340d99328463479df6deccb3fdae9",
+      "license": "Apache-2.0"
+    }
+  },
+  "dependencies": {
+    "metacall-polyglot-repl": {
+      "version": "git+ssh://git@github.com/metacall/polyglot-repl.git#d11d4bcf8ae340d99328463479df6deccb3fdae9",
+      "from": "metacall-polyglot-repl@github:metacall/polyglot-repl"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "jupyter-kernel-repl",
+  "version": "1.0.0",
+  "description": "REPL for the MetaCall Jupyter Kernel",
+  "main": "repl.js",
+  "directories": {
+    "doc": "docs",
+    "example": "examples"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/metacall/jupyter-kernel.git"
+  },
+  "keywords": [
+    "repl",
+    "metacall-jupyter-kernel",
+    "polyglot-repl"
+  ],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/metacall/jupyter-kernel/issues"
+  },
+  "homepage": "https://github.com/metacall/jupyter-kernel#readme",
+  "dependencies": {
+    "metacall-polyglot-repl": "github:metacall/polyglot-repl"
+  }
+}

--- a/repl.js
+++ b/repl.js
@@ -1,0 +1,1 @@
+require('metacall-polyglot-repl');

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ backcall==0.2.0
 debugpy==1.3.0
 decorator==5.0.9
 importlib-metadata==3.10.1
-ipykernel==6.0.0rc0
+ipykernel==6.0.2
 ipython==7.24.1
 ipython-genutils==0.2.0
 jedi==0.18.0

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author="Harsh Bardhan Mishra",
     author_email="erbeusgriffincasper@gmail.com",
     url="https://github.com/metacall/jupyter-kernel",
-    install_requires=["jupyter_client", "IPython", "ipykernel", "metacall", "guesslang"],
+    install_requires=["jupyter_client", "IPython", "ipykernel", "metacall"],
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
# Description

Fixes #36 

This PR: 

- Adds the MetaCall Polyglot REPL 
- Removes the `guesslang` dependency 
- Enables REPL to be used to loaded and inference carried out
- Refactors the MetaCall script execution through `>` tag
- Adds an example to showcase the use of REPL

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [ ] Documentation update
